### PR TITLE
LockClock: ForeCast: Remove finish transition

### DIFF
--- a/src/com/cyanogenmod/lockclock/weather/ForecastActivity.java
+++ b/src/com/cyanogenmod/lockclock/weather/ForecastActivity.java
@@ -1,5 +1,6 @@
 /*
  * Copyright (C) 2013 David van Tonder
+ * Copyright (C) 2017 The LineageOS Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -126,5 +127,11 @@ public class ForecastActivity extends Activity implements OnClickListener {
         } else {
             finish();
         }
+    }
+
+    @Override
+    public void finish() {
+        super.finish();
+        overridePendingTransition(0, 0);
     }
 }


### PR DESCRIPTION
* Opening the forecast from the widget makes the status bar and navigation
  bar semi-transparent
* When closing the dialog, it moves out to the bottom including the shadow
  of the status bar - which just looks wrong
* Remove the finish-animation to get rid of that

Change-Id: Ic14bcc096fd6b8a1af59eb5dc1a935a7c900d6e2